### PR TITLE
add CI

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,36 @@
+name: Build and push
+
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.DOCKER_REGISTRY }}
+          username: ${{ secrets.DOCKER_REGISTRY_USER }}
+          password: ${{ secrets.DOCKER_REGISTRY_PASS }}
+
+      - name: Tag name
+        id: tag_name
+        run: echo ::set-output name=TAG_NAME::${GITHUB_REF/refs\/tags\//}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: |
+            ${{ secrets.DOCKER_REGISTRY }}/vagahbond/picspy-api
+            ${{ secrets.DOCKER_REGISTRY }}/vagahbond/picspy-api:${{ steps.tag_name.outputs.TAG_NAME }}
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+        


### PR DESCRIPTION
Add a github action CI file. 

It is supposed to build the docker image and send it to a docker registry whenever a release is published.

In the end, a webhook will be added to it for procution to be updated with each release.﻿
